### PR TITLE
webpack now prepends the aws prefix to the asset folder when building…

### DIFF
--- a/ci/default.js
+++ b/ci/default.js
@@ -1,0 +1,3 @@
+module.exports = {
+  aws: { prefix: "hello-world" }
+}

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "mime-types": "^2.1.29",
     "node-dir": "^0.1.17",
     "prettier": "^2.2.1",
+    "process": "^0.11.10",
     "raw-loader": "^3.1.0",
     "terser-webpack-plugin": "^2.2.1",
     "webpack": "^4.41.2",

--- a/src/config/default.js
+++ b/src/config/default.js
@@ -1,9 +1,11 @@
 import "phaser";
+import { aws } from '../../ci/default'
 
 export default {
-  phaser: {
+  phaserConfig: {
     type: Phaser.AUTO,
     width: 800,
     height: 600,
   },
+  aws,
 };

--- a/src/core/loader.js
+++ b/src/core/loader.js
@@ -1,8 +1,6 @@
 import "phaser";
-import process from "process";
 import atlas from "../assets/atlas";
-import config from "../config/default-config";
-
+import config from "../config/default";
 const GAME_TOP = 2; // index of first non generic scene
 
 export default class Loader extends Phaser.Scene {
@@ -16,11 +14,11 @@ export default class Loader extends Phaser.Scene {
 }
 
 const runLoader = (scene) => {
-  // let env;
-  // const prefix = env === 'dev' ? `/${config.publish.prefix}` : '';
   atlas
     .getAll()
-    .forEach((pack) => scene.load.json(pack.key, `/assets/${pack.path}`)); // `${prefix}/assets/${pack.path}`
+    .forEach((pack) =>
+      scene.load.json(pack.key, `${config.aws.prefix}/assets/${pack.path}`)
+    );
   scene.load.start();
   scene.load.once("complete", () => {
     loadAssets(scene);
@@ -34,7 +32,10 @@ const loadAssets = (scene) => {
   atlas.getAll().forEach((pack) => {
     const packJson = scene.cache.json.get(pack.key);
     packJson.assets.forEach((asset) => {
-      scene.load.image(`${pack.prefix}.${asset.key}`, `/assets/${asset.path}`);
+      scene.load.image(
+        `${pack.prefix}.${asset.key}`,
+        `${config.aws.prefix}/assets/${asset.path}`
+      );
     });
   });
   scene.load.start();

--- a/src/index.js
+++ b/src/index.js
@@ -1,12 +1,12 @@
 import "phaser";
-import config from "./config/default-config";
+import config from "./config/default";
 import game from "./game";
 import Boot from "./core/boot";
 import Loader from "./core/loader";
 
 class Game extends Phaser.Game {
   constructor() {
-    super(config.phaser);
+    super(config.phaserConfig);
     this.scene.add("Boot", Boot);
     this.scene.add("Loader", Loader);
     game.scenes.forEach((cfg) => this.scene.add(cfg.key, cfg.scene));

--- a/webpack/base.js
+++ b/webpack/base.js
@@ -1,53 +1,58 @@
-const webpack = require('webpack');
-const path = require('path');
-const HtmlWebpackPlugin = require('html-webpack-plugin');
-const { CleanWebpackPlugin } = require('clean-webpack-plugin');
-const CopyPlugin = require('copy-webpack-plugin');
+const webpack = require("webpack");
+const path = require("path");
+const HtmlWebpackPlugin = require("html-webpack-plugin");
+const { CleanWebpackPlugin } = require("clean-webpack-plugin");
+const CopyPlugin = require("copy-webpack-plugin");
+const config = require("../ci/default");
 
-// const process = require('process');
-
-// const prefix = process.env.PHASER_ENV === 'dev' ? '' : 'hello-world/';
+const isDevEnv = process.env.PHASER_ENV === "dev";
+console.log("BEEBUG: isDevEnv: ", isDevEnv);
+const prefix = isDevEnv ? `${config.aws.prefix}/` : "";
+console.log("BEEBUG: prefix: ", prefix);
 
 module.exports = {
-    entry: './src/index.js',
-    mode: 'development',
-    devtool: 'eval-source-map',
-    devServer: {
-        port: 8080,
-        contentBase: path.resolve(__dirname, '../src/assets'),
-    },
-    module: {
-        rules: [
-            {
-                test: /\.js$/,
-                exclude: /node_modules/,
-                use: {
-                    loader: 'babel-loader',
-                },
-            },
-            {
-                test: [/\.vert$/, /\.frag$/],
-                use: 'raw-loader',
-            },
-            {
-                test: /\.(gif|png|jpe?g|svg|xml)$/i,
-                use: 'file-loader',
-            },
-        ],
-    },
-    plugins: [
-        new CleanWebpackPlugin({
-            root: path.resolve(__dirname, '../'),
-        }),
-        new CopyPlugin({
-            patterns: [{ from: 'src/assets', to: `./assets` }],
-        }),
-        new webpack.DefinePlugin({
-            CANVAS_RENDERER: JSON.stringify(true),
-            WEBGL_RENDERER: JSON.stringify(true),
-        }),
-        new HtmlWebpackPlugin({
-            template: './index.html',
-        }),
+  entry: "./src/index.js",
+  mode: "development",
+  devtool: "eval-source-map",
+  devServer: {
+    port: 8080,
+    contentBase: path.resolve(__dirname, "../src/assets"),
+  },
+  module: {
+    rules: [
+      {
+        test: /\.js$/,
+        exclude: /node_modules/,
+        use: {
+          loader: "babel-loader",
+        },
+      },
+      {
+        test: [/\.vert$/, /\.frag$/],
+        use: "raw-loader",
+      },
+      {
+        test: /\.(gif|png|jpe?g|svg|xml)$/i,
+        use: "file-loader",
+      },
     ],
+  },
+  plugins: [
+    new CleanWebpackPlugin({
+      root: path.resolve(__dirname, "../"),
+    }),
+    new CopyPlugin({
+      patterns: [{ from: "src/assets", to: `./${prefix}/assets` }],
+    }),
+    new webpack.DefinePlugin({
+      CANVAS_RENDERER: JSON.stringify(true),
+      WEBGL_RENDERER: JSON.stringify(true),
+    }),
+    new HtmlWebpackPlugin({
+      template: "./index.html",
+    }),
+  ],
+  node: {
+    fs: "empty",
+  },
 };

--- a/webpack/prod.js
+++ b/webpack/prod.js
@@ -1,26 +1,26 @@
-const merge = require('webpack-merge');
-const base = require('./base');
-const TerserPlugin = require('terser-webpack-plugin');
+const merge = require("webpack-merge");
+const base = require("./base");
+const TerserPlugin = require("terser-webpack-plugin");
 
 module.exports = merge(base, {
-    mode: 'production',
-    output: {
-        filename: 'bundle.min.js',
-    },
-    devtool: false,
-    performance: {
-        maxEntrypointSize: 1100000,
-        maxAssetSize: 1100000,
-    },
-    optimization: {
-        minimizer: [
-            new TerserPlugin({
-                terserOptions: {
-                    output: {
-                        comments: false,
-                    },
-                },
-            }),
-        ],
-    },
+  mode: "production",
+  output: {
+    filename: "bundle.min.js",
+  },
+  devtool: false,
+  performance: {
+    maxEntrypointSize: 1100000,
+    maxAssetSize: 1100000,
+  },
+  optimization: {
+    minimizer: [
+      new TerserPlugin({
+        terserOptions: {
+          output: {
+            comments: false,
+          },
+        },
+      }),
+    ],
+  },
 });


### PR DESCRIPTION
… locally. This means the loader can unconditionally use the prefix. That means we don't need to parameterise at runtime.